### PR TITLE
Limit sharing to cap information reach and show results

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,8 @@
             <button onclick="iniciarSimulacao()">Iniciar</button>
             <button onclick="resetarSimulacao()">Resetar</button>
         </div>
-        <canvas id="quadro" width="700" height="500"></canvas> 
+        <canvas id="quadro" width="700" height="500"></canvas>
+        <p id="resultado" class="resultado"></p>
 
         <div class="legenda">
             <h3>Legenda:</h3>

--- a/script.js
+++ b/script.js
@@ -43,6 +43,7 @@ class No {
         this.estado = 'nao_viu';
         this.vizinhos = [];
         this.tempoVerificacao = Math.floor(Math.random() * frequenciaVerificacao);
+        this.jaCompartilhou = false;
     }
 
     desenhar() {
@@ -125,17 +126,29 @@ function executarPasso() {
     });
 
     nos.forEach((no, i) => {
-        if (no.estado === 'recebido' && Math.random() < chanceCompartilhar) {
+        if (no.estado === 'recebido' && !no.jaCompartilhou && Math.random() < chanceCompartilhar) {
             paraCompartilhar.push(i);
         }
     });
 
-    paraCompartilhar.forEach(i => nos[i].estado = 'compartilhando');
+    paraCompartilhar.forEach(i => {
+        nos[i].estado = 'compartilhando';
+        nos[i].jaCompartilhou = true;
+    });
     paraAprender.forEach(i => nos[i].estado = 'consciente');
 
     desenharRede();
     tempo++;
-    setTimeout(() => requestAnimationFrame(executarPasso), velocidade);
+
+    const aindaEspalhando = nos.some(no => no.estado === 'compartilhando') ||
+        nos.some(no => no.estado === 'recebido' && !no.jaCompartilhou);
+
+    if (aindaEspalhando) {
+        setTimeout(() => requestAnimationFrame(executarPasso), velocidade);
+    } else {
+        rodando = false;
+        mostrarResultado();
+    }
 }
 
 function iniciarSimulacao() {
@@ -149,6 +162,14 @@ function resetarSimulacao() {
     rodando = false;
     tempo = 0;
     configurarRede();
+    document.getElementById('resultado').textContent = '';
+}
+
+function mostrarResultado() {
+    const totalRecebeu = nos.filter(no => no.estado !== 'nao_viu').length;
+    const totalCompartilhou = nos.filter(no => no.jaCompartilhou).length;
+    document.getElementById('resultado').textContent =
+        `Alcance: ${totalRecebeu}/${quantidadeNos} pessoas, ${totalCompartilhou} compartilharam.`;
 }
 
 configurarRede();

--- a/style.css
+++ b/style.css
@@ -100,6 +100,11 @@ main {
     text-align: center;
 }
 
+.resultado {
+    margin-top: 10px;
+    font-weight: bold;
+}
+
 
 button {
     background-color: var(--cor-destaque);


### PR DESCRIPTION
## Summary
- Ensure each node shares only once and stop simulation when propagation ceases
- Display final reach statistics and style them

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3068d8f08321a20ff275413ec0fc