### PR TITLE
Limit sharing and visualize information paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,8 @@
             <button onclick="iniciarSimulacao()">Iniciar</button>
             <button onclick="resetarSimulacao()">Resetar</button>
         </div>
-        <canvas id="quadro" width="700" height="500"></canvas> 
+        <canvas id="quadro" width="700" height="500"></canvas>
+        <p id="resultado" class="resultado"></p>
 
         <div class="legenda">
             <h3>Legenda:</h3>
@@ -71,9 +72,11 @@
                     <div class="amostra-legenda" style="background-color: purple;"></div>
                     <p>Recebeu a informação e não compartilhou</p>
                 </div>
+                <div class="item-legenda">
+                    <div class="linha-legenda"></div>
+                    <p>Caminho da informação</p>
+                </div>
             </div>
-        </div>
-
         </div>
         <p>
             Este recurso é destinado exclusivamente a fins didáticos. Não utiliza nem coleta dados reais de pessoas ou redes sociais; trata-se apenas de uma simulação para fins de aprendizado.

--- a/style.css
+++ b/style.css
@@ -100,6 +100,11 @@ main {
     text-align: center;
 }
 
+.resultado {
+    margin-top: 10px;
+    font-weight: bold;
+}
+
 
 button {
     background-color: var(--cor-destaque);
@@ -200,4 +205,10 @@ input[type="range"]::-moz-range-track {
     height: 20px;
     border-radius: 4px;
     border: 1px solid #333;
+}
+
+.linha-legenda {
+    width: 20px;
+    height: 4px;
+    background-color: var(--cor-laranja);
 }


### PR DESCRIPTION
## Summary
- Track sharing routes and draw arrows to highlight how information travels
- Add legend entry for the new path visualization

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3068d8f08321a20ff275413ec0fc